### PR TITLE
Add github action linter

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,17 @@
+name: Static checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  static-checks:
+    name: 'Static checks'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: Scony/godot-gdscript-toolkit@master
+    - run: gdformat --check source/
+    - run: gdlint source/


### PR DESCRIPTION
ensures that pull requests to main must pass gdscript linter checks. To apply linter to your code, follow instructions [here](https://github.com/Scony/godot-gdscript-toolkit)
closes #24 